### PR TITLE
Minor documentation corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,36 +5,36 @@ Why a new feed format, we already have [gabby grove] and [bamboo]?
 > Because we would want to offer a feed format for [meta feeds] that is
 > simple and easy to implement in any programming language by reusing an
 > established format ([bencode]) with existing encoder libraries.
-> Furthermore as meta feeds makes it a easier to have multiple feed formats
+> Furthermore, as meta feeds makes it easier to have multiple feed formats,
 > we wanted to show that creating a new feed format does not have to be hard.
 
 Can't you just use the classic format?
 
 > That would mean clients would have to support reading and writing the
-> classic forever, even for applications that only use newer feed formats.
+> classic format forever, even for applications that only use newer feed formats.
 
-What is wrong with classic format?
+What is wrong with the classic format?
 
 > There are multiple problems, most of them come from the fact that
 > it is very tied to the internals of the v8 engine for Javascript.
 > JSON is good as an exchange format for values of data but not well
-> suited to cryptographically sign messages where a canonical represantion
+> suited to cryptographically sign messages where a canonical representation
 > of each value is paramount.
 
 ## Details
 
 A message is encoded via [bencode] as an array of message payload and signature.
-SSB binary field encodings ([SSB-BFE]) is used to disambiguate binary data like `author` or `previous` from ordinaty byte strings.
+SSB binary field encodings ([SSB-BFE]) is used to disambiguate binary data like `author` or `previous` from ordinary byte strings.
 
-Message payload, an array with 5 elements, in this specific order:
+Message payload; an array with 5 elements in this specific order:
 
 1) `author` a binary [SSB-BFE] encoded feed id
 2) `sequence` a 32 bit integer starting at 1
 3) `previous` a binary [SSB-BFE] encoded message id of the previous message
   on the feed. For the first message this must be zero bytes.
-4) `time` an integer representing the UNIX epoch timestamp the message
-  was created
-5) `content` an array of a dictionary encoded the data relevant to the
+4) `time` an integer representing the UNIX epoch timestamp of message
+  creation
+5) `content` an array of a dictionary encoding the data relevant to the
   meta feed and a signature. The signature is the concatenation of the
   string 'metafeeds' encoded as bytes and the bytes of the content
   payload, signed using the private key of the sub feed. If content is
@@ -44,13 +44,13 @@ Message payload, an array with 5 elements, in this specific order:
 Signature:
 
 - the encoded bytes of the message payload entry in the array signed using the
-  private key of the meta feed.
+  private key of the meta feed
 
 Example (FIXME: proper data):
 
 ```js
 [
-  // paylod
+  // payload
   [
     // author
     <Buffer 00 02 e8 20 31 38 8d df f8 b5 0e 56 b6 c0 97 42 1e 9a a8 92 ec 04 e9 42 fa fd 31 dc 3d 2c 2e 3e 52 fd>,
@@ -77,9 +77,9 @@ Example (FIXME: proper data):
 ]
 ```
 
-To achive domain separation, the content bytes are prefixed with
+To achieve domain separation, the content bytes are prefixed with
 the string `metafeeds` when it is signed and verified.
-This assures that the signature can only be used for
+This ensures that the signature can only be used for
 meta feed signatures and not for anything else.
 
 For signatures we use the same [HMAC signing capability]
@@ -91,28 +91,30 @@ of message payload and signature as bytes.
 
 ## Validation
 
-For validation we differentiate between if the message is valid and if
-the content is valid. Since the content can be encrypted there is
-potentially no way to validate that. This means a message should only
-be rejected before it is inserted in the local database if it fails
-the message validation rules and not be included in the state of the
+For validation we differentiate between message validity and content
+validity. Since the content can be encrypted, there is potentially
+no way to validate that. This means a message should only be rejected
+before insertion into the local database if it fails the message
+validation rules. A message should not be included in the state of the
 meta feed if content is not valid.
 
 Message must conform to the following rules:
+
  - Must be in the format specified above
  - The `previous` field must be correct (reference the previous message)
  - The `signature` field must be valid
- - The [SSB-BFE] format for `author` and `previous` must stay the same,
-   there is no upgradeability in the middle of a feed
+ - The [SSB-BFE] format for `author` and `previous` must stay the same
+(there is no upgradeability in the middle of a feed)
  - The `author` can not change between two messages (always stays the same)
- - The maximum size of a message in bytes must not exceed 8192 bytes.
+ - The maximum size of a message in bytes must not exceed 8192 bytes
 
 Content must conform to the following rules:
- - a type field with a string value of only the following values
+
+ - a `type` field with a string value of only the following values
    possible: `metafeed/add`, `metafeed/update` or `metafeed/tombstone`
- - a subfeed field with a [SSB-BFE] encoded feed id
- - a metafeed field with a [SSB-BFE] encoded feed id
- - a nonce field with a 32 bit random integer value
+ - a `subfeed` field with a [SSB-BFE] encoded feed id
+ - a `metafeed` field with a [SSB-BFE] encoded feed id
+ - a `nonce` field with a 32 bit random integer value
  - the content signature must be correct
 
 


### PR DESCRIPTION
There isn't anything too major in this PR. I worked through the text and corrected any spelling errors I could find. I also made a few punctuation / grammar changes to improve readability.

I have not yet done a deep-read for understanding of the format, but one thing did stick-out to me during this initial review:

The `payload` example includes the following (referring to `type`, `feedformat` and `feedpurpose`):

```
      // content
      { 
        type: 'metafeed/add', 
        feedformat: 'classic', 
        feedpurpose: 'main', 
        ...
      },
```

Yet the `content` validation section refers to `type`, `subfeed` and `metafeed`. Are these different names for the same fields or does the `content` payload include all four fields (ie. `feedformat`, `feedpurpose`, `subfeed` and `metafeed`)?

One other pedantic suggestion would be to settle on either `meta feed` or `metafeed` for use throughout the documentation. I admit this is purely a cosmetic consistency thing to satisfy the lexical conformist in my brain ;)

-----

> The maximum size of a message in bytes must not exceed 8192 **bytes**

🥳 ❤️ 🥳 